### PR TITLE
fix #432 Enlever l'image avec le point d'interrogation si absence de

### DIFF
--- a/src/Innova/SelfBundle/Resources/views/Player/CE/consigne.html.twig
+++ b/src/Innova/SelfBundle/Resources/views/Player/CE/consigne.html.twig
@@ -1,12 +1,14 @@
 <div class="question-CE">
-    <img width="70px" src="{{ asset("bundles/innovaself/images/") }}oignon.png" rel="tooltip" data-original-title="{{ 'player.tooltip.question' | trans }}" />
+    {#fix #432 : Enlever l'image avec le point d'interrogation si absence de consigne #}
     {% if subquestion.mediaAmorce is not null %}
+        <img width="70px" src="{{ asset("bundles/innovaself/images/") }}oignon.png" rel="tooltip" data-original-title="{{ 'player.tooltip.question' | trans }}" />
         <div class="question-CE-text">
             {% autoescape %}
                 {{ subquestion.mediaAmorce.description|raw }}
             {% endautoescape %}
         </div>
     {% elseif questionnaire.mediaInstruction is not null %}
+        <img width="70px" src="{{ asset("bundles/innovaself/images/") }}oignon.png" rel="tooltip" data-original-title="{{ 'player.tooltip.question' | trans }}" />
         <div class="question-CE-text">
             {% autoescape %}
                 {{ questionnaire.mediaInstruction.description|raw }}


### PR DESCRIPTION
consigne
